### PR TITLE
chore: make buf SDKs to be public

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,10 +44,6 @@ jobs:
 
       - uses: bufbuild/buf-setup-action@v1
 
-      - name: Login to Buf Schema Registry
-        run: |
-          echo ${{ secrets.BUF_TOKEN }} | buf registry login buf.build --token-stdin
-
       - name: Install dependencies
         run: cd backend && make install
 
@@ -120,11 +116,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.12'
-
-      - name: Set up Buf
-        run: |
-          npm config set @buf:registry https://buf.build/gen/npm/v1/ && \
-          npm config set //buf.build/gen/npm/v1/:_authToken ${{ secrets.BUF_TOKEN }}
 
       - name: Install dependencies
         run: cd frontend && npm ci

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,10 +6,6 @@ WORKDIR /src
 ADD Makefile ./
 RUN make install-build
 
-RUN --mount=type=secret,id=buf_token \
-    BUF_TOKEN=$(cat /run/secrets/buf_token) && \
-    echo "$BUF_TOKEN" | buf registry login buf.build --token-stdin
-
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=bind,source=go.mod,target=go.mod \
     go mod download -x

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -12,10 +12,6 @@ WORKDIR /src
 ADD Makefile ./
 RUN make install-build install-dev
 
-RUN --mount=type=secret,id=buf_token \
-    BUF_TOKEN=$(cat /run/secrets/buf_token) && \
-    echo "$BUF_TOKEN" | buf registry login buf.build --token-stdin
-
 ADD . .
 
 ADD go.mod go.sum ./

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,8 +6,6 @@ services:
       args:
         MAIN_GO_FILE: /src/cmd/api/main.go
         BIN_NAME: api
-      secrets:
-        - buf_token
     env_file:
       - .env.docker
     volumes:
@@ -22,8 +20,6 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
       target: dev
-      secrets:
-        - buf_token
     volumes:
       - ./frontend:/usr/src:delegated
       - /usr/src/build
@@ -64,10 +60,6 @@ services:
       interval: 1s
       timeout: 3s
       retries: 30
-
-secrets:
-  buf_token:
-    file: secrets/buf_token
 
 volumes:
   go:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,11 +5,6 @@ FROM node:${NODE_VERSION} AS base
 WORKDIR /usr/src
 COPY package*.json ./
 
-RUN --mount=type=secret,id=buf_token \
-    BUF_TOKEN=$(cat /run/secrets/buf_token) && \
-    npm config set @buf:registry https://buf.build/gen/npm/v1/ && \
-    npm config set //buf.build/gen/npm/v1/:_authToken "$BUF_TOKEN"
-
 RUN --mount=type=cache,target=/root/.npm \
     npm install
 


### PR DESCRIPTION
This pull request focuses on removing the Buf Schema Registry login and token setup from various configuration files. The changes include updates to GitHub workflow files, Dockerfiles, and the Docker Compose configuration.

### Removal of Buf Schema Registry setup:

* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L47-L50): Removed steps to login to Buf Schema Registry and set up Buf in both backend and frontend jobs. [[1]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L47-L50) [[2]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L124-L128)
* [`backend/Dockerfile`](diffhunk://#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486L9-L12): Removed the Buf Schema Registry login using a secret token.
* [`backend/Dockerfile.dev`](diffhunk://#diff-fc0781121c673bc4c7088af7eac47a57f25d9dd6c40e983cf4bb320d660d2967L15-L18): Removed the Buf Schema Registry login using a secret token.
* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL9-L10): Removed the `buf_token` secret from service configurations and the global secrets section. [[1]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL9-L10) [[2]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL25-L26) [[3]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL68-L71)
* [`frontend/Dockerfile`](diffhunk://#diff-ea60ef29f6f537c1c83468c00b60de28f86e06edfe4a3d91274723c6f298fdb8L8-L12): Removed the Buf Schema Registry login and npm configuration setup using a secret token.