### PR TITLE
feat: allow only trusted IP for SSH connection

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,6 +20,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::590183691452:role/GitHubActionsRole-590183691452
+          aws-region: ap-northeast-1
+
+      - name: Get Public IP
+        id: ip
+        uses: haythem/public-ip@v1.3
+
+      - name: Allow IP in Security Group
+        run: |
+          aws ec2 authorize-security-group-ingress \
+          --group-id ${{ secrets.SECURITY_GROUP_ID_STG }} \
+          --protocol tcp \
+          --port ${{ secrets.SSH_PORT_STG }} \
+          --cidr ${{ steps.ip.outputs.ipv4 }}/32
+
       - name: Set up SSH
         run: |
           echo "${{ secrets.EC2_SSH_KEY_STG }}" | base64 --decode > key.pem
@@ -43,16 +61,6 @@ jobs:
           
           ansible-playbook -i ./inventory/web.yaml playbook.yaml \
           --vault-password-file ./secrets/ansible_vault_pass --limit stg \
-
-      - name: Public IP
-        id: ip
-        uses: haythem/public-ip@v1.3
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::590183691452:role/GitHubActionsRole-590183691452
-          aws-region: ap-northeast-1
 
       - name: Set adhoc branch name
         run: |
@@ -104,3 +112,12 @@ jobs:
             sudo systemctl restart sampay-worker
             sudo systemctl restart sampay-frontend
           EOF
+
+      - name: Revoke IP from Security Group
+        if: ${{ always() }}
+        run: |
+          aws ec2 revoke-security-group-ingress \
+            --group-id ${{ secrets.SECURITY_GROUP_ID_STG }} \
+            --protocol tcp \
+            --port ${{ secrets.SSH_PORT_STG }} \
+            --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/infra/environments/stg/main.tf
+++ b/infra/environments/stg/main.tf
@@ -78,6 +78,7 @@ module "sg" {
 
   github_repo = var.github_repo
   ssh_port    = var.ssh_port
+  trusted_ip  = var.trusted_ip
   vpc_id      = module.vpc.vpc_id
 }
 

--- a/infra/environments/stg/variables.tf
+++ b/infra/environments/stg/variables.tf
@@ -107,6 +107,11 @@ variable "ssh_public_key_path" {
   type        = string
 }
 
+variable "trusted_ip" {
+  description = "Trusted IP address"
+  type        = string
+}
+
 variable "volume_size" {
   description = "Volume size in GB"
   type        = number

--- a/infra/modules/sg/main.tf
+++ b/infra/modules/sg/main.tf
@@ -36,11 +36,11 @@ resource "aws_security_group" "ssh" {
   vpc_id      = var.vpc_id
 
   ingress {
-    description = "Allow SSH"
+    description = "Allow SSH from trusted IP"
     from_port   = var.ssh_port
     to_port     = var.ssh_port
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.trusted_ip]
   }
 
   egress {

--- a/infra/modules/sg/variables.tf
+++ b/infra/modules/sg/variables.tf
@@ -8,6 +8,11 @@ variable "github_repo" {
   type        = string
 }
 
+variable "trusted_ip" {
+  description = "Trusted IP address"
+  type        = string
+}
+
 variable "ssh_port" {
   description = "SSH port"
   type        = number


### PR DESCRIPTION
This pull request introduces changes to the infrastructure configuration to enhance security by restricting SSH access to a trusted IP address. The most important changes include adding a new variable for the trusted IP address and updating the security group configuration to use this variable.

### Security Enhancements:

* [`infra/environments/stg/main.tf`](diffhunk://#diff-f4b768ff9206fb074ac567a4a89911a3422ff54a95cbc72b5de0bf1a372a2881R81): Added `trusted_ip` variable to the module configuration.
* [`infra/environments/stg/variables.tf`](diffhunk://#diff-189d88c07015eb76dd4394c6352f42d9679bf31773b970785941d006ad61b2f5R110-R114): Introduced a new variable `trusted_ip` to store the trusted IP address.
* [`infra/modules/sg/main.tf`](diffhunk://#diff-df030f454d37484737f96514e117212bb17ec788cc316988f5041f8176ac13faL39-R43): Updated the security group ingress rule to allow SSH access only from the trusted IP address.
* [`infra/modules/sg/variables.tf`](diffhunk://#diff-0f77ef3ceeac5750fa6dcb71fd88554f399d6e9be5c422b6349722f6f02ddd5dR11-R15): Added a new variable `trusted_ip` to the module variables.