### PR TITLE
ci: deploy only binaries

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,72 +46,66 @@ jobs:
       - name: Set ansible vault password
         run: |
           mkdir -p provisioning/secrets
-          echo "${{ secrets.ANSIBLE_VAULT_PASS }}" > ./provisioning/secrets/ansible_vault_pass 
+          echo "${{ secrets.ANSIBLE_VAULT_PASS }}" > ./provisioning/secrets/ansible_vault_pass
 
       - name: Execute ansible playbook
         run: |
           cd ./provisioning
-          
+
           export ANSIBLE_SSH_KEY="${GITHUB_WORKSPACE}/key.pem"
           export ANSIBLE_SSH_PORT=${{ secrets.SSH_PORT_STG }}
           export AWS_REGION=${{ env.AWS_REGION }}
           export CERTBOT_EMAIL=${{ secrets.CERTBOT_EMAIL }}
           export POSTGRES_PASSWORD=${{ secrets.POSTGRES_ADMIN_PASSWORD_STG }}
           export KVS_PASSWORD=${{ secrets.KVS_PASSWORD_STG }}
-          
+
           ansible-playbook -i ./inventory/web.yaml playbook.yaml \
           --vault-password-file ./secrets/ansible_vault_pass --limit stg \
 
-      - name: Set adhoc branch name
-        run: |
-          echo "ADHOC_BRANCH_NAME=adhoc/${{ github.sha }}-$(echo ${{ github.event.repository.updated_at }} | sed 's/[:]/_/g')" >> $GITHUB_ENV
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./backend/go.mod
+          cache-dependency-path: ./backend/go.sum
 
-      - name: Checkout repository on EC2
+      - name: Set directory suffix
         run: |
-          ssh -p ${{ secrets.SSH_PORT_STG }} -o StrictHostKeyChecking=no -i key.pem ec2-user@${{ env.DOMAIN }} << 'EOF'
-            set -eux -o pipefail
-            export ADHOC_BRANCH_NAME="${{ env.ADHOC_BRANCH_NAME }}"
-            if [ ! -d "sampay" ]; then
-              git clone git@github.com:mickamy/sampay.git
-            fi
-            cd sampay
-            git checkout -b "$ADHOC_BRANCH_NAME" 
-            git add .
-            git stash
-            git branch --merged | grep -v \* | xargs git branch -D
-            git fetch origin --prune
-            git branch -D ${{ github.ref_name }} || true
-            git checkout ${{ github.ref_name }}
-          EOF
+          echo "DIR_SUFFIX=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
+
+      - name: Build backend binaries
+        run: cd backend && make build
+
+      - name: Ensure app directory exists
+        run: |
+          ssh -p ${{ secrets.SSH_PORT_STG }} -i key.pem ec2-user@${{ env.DOMAIN }} -o StrictHostKeyChecking=no '
+            mkdir -p /home/ec2-user/sampay
+          '
+
+      - name: Copy binaries to EC2 (build & db)
+        run: |
+          scp -r -i key.pem -P ${{ secrets.SSH_PORT_STG }} -o StrictHostKeyChecking=no \
+            ./backend/build ./backend/db ec2-user@${{ env.DOMAIN }}:/home/ec2-user/sampay/backend-${{ env.DIR_SUFFIX }}/
 
       - name: Deploy backend application
         run: |
-          ssh -p ${{ secrets.SSH_PORT_STG }} -o StrictHostKeyChecking=no -i key.pem ec2-user@${{ env.DOMAIN }} \
-            "bash ~/sampay/backend/bin/deploy.sh"
+          cat "${GITHUB_WORKSPACE}/backend/bin/deploy.sh" |
+          ssh -p ${{ secrets.SSH_PORT_STG }} -i key.pem ec2-user@${{ env.DOMAIN }} -o StrictHostKeyChecking=no '
+            export DIR_SUFFIX="${{ env.DIR_SUFFIX }}";
+            bash -s
+          '
+
+      - name: Copy frontend files to EC2
+        run: |
+          scp -C -r -i key.pem -P ${{ secrets.SSH_PORT_STG }} -o StrictHostKeyChecking=no \
+            ./frontend ec2-user@${{ env.DOMAIN }}:/home/ec2-user/sampay/frontend-${{ env.DIR_SUFFIX }}
 
       - name: Deploy frontend application
         run: |
-          ssh -p ${{ secrets.SSH_PORT_STG }} -o StrictHostKeyChecking=no -i key.pem ec2-user@${{ env.DOMAIN }} \
-            "bash ~/sampay/frontend/bin/deploy.sh"
-
-      - name: Delete adhoc branch
-        run: |
-          ssh -p ${{ secrets.SSH_PORT_STG }} -o StrictHostKeyChecking=no -i key.pem ec2-user@${{ env.DOMAIN }} << 'EOF'
-            cd sampay
-            export ADHOC_BRANCH_NAME="${{ env.ADHOC_BRANCH_NAME }}"
-            git branch -D "$ADHOC_BRANCH_NAME"
-          EOF
-
-      - name: Rollback
-        if: ${{ failure() }}
-        run: |
-          ssh -p ${{ secrets.SSH_PORT_STG }} -o StrictHostKeyChecking=no -i key.pem ec2-user@${{ env.DOMAIN }} << 'EOF'
-            cd sampay
-            git checkout -
-            sudo systemctl restart sampay-api
-            sudo systemctl restart sampay-worker
-            sudo systemctl restart sampay-frontend
-          EOF
+          cat "${GITHUB_WORKSPACE}/frontend/bin/deploy.sh" |
+          ssh -p ${{ secrets.SSH_PORT_STG }} -i key.pem ec2-user@${{ env.DOMAIN }} -o StrictHostKeyChecking=no '
+            export DIR_SUFFIX="${{ env.DIR_SUFFIX }}";
+            bash -s
+          '
 
       - name: Revoke IP from Security Group
         if: ${{ always() }}

--- a/backend/bin/deploy.sh
+++ b/backend/bin/deploy.sh
@@ -1,32 +1,70 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
-cd ~/sampay
-git pull
+if [ -z "${DIR_SUFFIX:-}" ]; then
+    echo "DIR_SUFFIX is not set. Exiting."
+    exit 1
+fi
 
-cd backend
-make build db-prepare
-sudo systemctl restart sampay-api
-sudo systemctl restart sampay-worker
+NEW_DIR="/home/ec2-user/sampay/backend-$DIR_SUFFIX"
 
+APP_DIR="/home/ec2-user/sampay/backend"
+PREVIOUS_VERSION_LINK=$(readlink -f "$APP_DIR" || echo "")
+
+if [ "$PREVIOUS_VERSION_LINK" = "$APP_DIR" ]; then
+    PREVIOUS_VERSION_LINK=""
+fi
+
+
+echo "Preparing database..."
+export PACKAGE_ROOT="$NEW_DIR"
+if ! ( "$NEW_DIR/build/db-create" && "$NEW_DIR/build/db-migrate" && "$NEW_DIR/build/db-seed" ); then
+    echo "Error: Database preparation failed. Exiting."
+    rm -rf "$NEW_DIR"
+    exit 1
+fi
+
+echo "Update symlink to new version..."
+if ! ln -sfn "$NEW_DIR" "$APP_DIR"; then
+    echo "Error: Failed to update symlink. Exiting."
+    rm -rf "$NEW_DIR"
+    exit 1
+fi
+
+function rollback() {
+    echo "Rolling back to previous version..."
+    if [ -n "$PREVIOUS_VERSION_LINK" ]; then
+        ln -sfn "$PREVIOUS_VERSION_LINK" "$APP_DIR"
+    fi
+    sudo systemctl restart sampay-api sampay-worker
+    rm -rf "$NEW_DIR"
+    exit 1
+}
+
+echo "Restarting sampay-api and sampay-worker services..."
+if ! sudo systemctl restart sampay-api sampay-worker; then
+    echo "Error: Failed to restart sampay-api and sampay-worker services."
+    rollback
+fi
+
+echo "Waiting for sampay-worker service to become active..."
 if timeout 10s bash -c 'until systemctl is-active --quiet sampay-worker; do sleep 1; done'; then
     echo "sampay-worker service is now active."
 else
     echo "Timed out waiting for sampay-worker service to become active."
-    exit 1
+    rollback
 fi
 
 echo "Waiting for sampay-api service to become active..."
 retry_count=0
 max_retries=3
 retry_interval=5
-
 while [ $retry_count -lt $max_retries ]; do
     if systemctl is-active --quiet sampay-api; then
         echo "sampay-api service is active."
         if wget -q --spider http://localhost:8080/api/health; then
             echo "Health check passed successfully."
-            exit 0
+            break
         else
             echo "Health check failed. Retrying..."
         fi
@@ -40,7 +78,13 @@ while [ $retry_count -lt $max_retries ]; do
         echo "Retrying in $retry_interval seconds... (Attempt $retry_count of $max_retries)"
         sleep $retry_interval
     fi
+
+    if [ $retry_count -eq $max_retries ]; then
+        echo "Error: Failed to start sampay-api service."
+        rollback
+    fi
 done
 
-echo "Failed to verify sampay-api service health after $max_retries attempts."
-exit 1
+echo "Deployment completed successfully."
+echo "Removing old version directory: $PREVIOUS_VERSION_LINK"
+rm -rf "$PREVIOUS_VERSION_LINK"

--- a/frontend/bin/deploy.sh
+++ b/frontend/bin/deploy.sh
@@ -1,8 +1,59 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
-cd ~/sampay
-git pull
+if [ -z "${DIR_SUFFIX:-}" ]; then
+    echo "DIR_SUFFIX is not set. Exiting."
+    exit 1
+fi
 
-cd frontend
-sudo systemctl restart sampay-frontend
+NEW_DIR="/home/ec2-user/sampay/frontend-$DIR_SUFFIX"
+
+APP_DIR="/home/ec2-user/sampay/frontend"
+PREVIOUS_VERSION_LINK=$(readlink -f "$APP_DIR" || echo "")
+
+if [ "$PREVIOUS_VERSION_LINK" = "$APP_DIR" ]; then
+    PREVIOUS_VERSION_LINK=""
+fi
+
+echo "Building application..."
+cd "$NEW_DIR" || exit 1
+if ! ( npm ci && npm run build ); then
+    echo "Error: Build failed. Exiting."
+    rm -rf "$NEW_DIR"
+    exit 1
+fi
+
+echo "Update symlink to new version..."
+if ! ln -sfn "$NEW_DIR" "$APP_DIR"; then
+    echo "Error: Failed to update symlink. Exiting."
+    rm -rf "$NEW_DIR"
+    exit 1
+fi
+
+function rollback() {
+    echo "Rolling back to previous version..."
+    if [ -n "$PREVIOUS_VERSION_LINK" ]; then
+        ln -sfn "$PREVIOUS_VERSION_LINK" "$APP_DIR"
+    fi
+    sudo systemctl restart sampay-api sampay-worker
+    rm -rf "$NEW_DIR"
+    exit 1
+}
+
+echo "Restarting sampay-frontend service..."
+if ! sudo systemctl restart sampay-frontend; then
+    echo "Error: Failed to restart sampay-frontend service."
+    rollback
+fi
+
+echo "Waiting for sampay-frontend service to become active..."
+if timeout 10s bash -c 'until systemctl is-active --quiet sampay-frontend; do sleep 1; done'; then
+    echo "sampay-frontend service is now active."
+else
+    echo "Timed out waiting for sampay-frontend service to become active."
+    rollback
+fi
+
+echo "Deployment completed successfully."
+echo "Removing old version directory: $PREVIOUS_VERSION_LINK"
+rm -rf "$PREVIOUS_VERSION_LINK"

--- a/provisioning/playbooks/backend.yaml
+++ b/provisioning/playbooks/backend.yaml
@@ -86,3 +86,19 @@
         create: true
         state: present
         mode: '0644'
+
+    - name: Set PACKAGE_ROOT to /etc/environment
+      ansible.builtin.lineinfile:
+        path: /etc/environment
+        line: "PACKAGE_ROOT=/home/ec2-user/sampay/backend"
+        create: true
+        state: present
+        mode: '0644'
+
+    - name: Create directory
+      ansible.builtin.file:
+        path: /home/ec2-user/sampay
+        state: directory
+        owner: ec2-user
+        group: ec2-user
+        mode: '0755'

--- a/provisioning/playbooks/frontend.yaml
+++ b/provisioning/playbooks/frontend.yaml
@@ -13,10 +13,6 @@
 
           [Service]
           WorkingDirectory=/home/ec2-user/sampay/frontend
-          ExecStartPre=/home/ec2-user/.nvm/versions/node/{{ node_version }}/bin/node \
-            /home/ec2-user/.nvm/versions/node/{{ node_version }}/bin/npm ci
-          ExecStartPre=/home/ec2-user/.nvm/versions/node/{{ node_version }}/bin/node \
-            /home/ec2-user/.nvm/versions/node/{{ node_version }}/bin/npm run build
           ExecStart=/home/ec2-user/.nvm/versions/node/{{ node_version }}/bin/node \
             /home/ec2-user/.nvm/versions/node/{{ node_version }}/bin/npm run start
           EnvironmentFile=/etc/systemd/system/sampay-frontend.env
@@ -57,3 +53,11 @@
       ansible.builtin.systemd:
         name: sampay-frontend
         enabled: true
+
+    - name: Create directory
+      ansible.builtin.file:
+        path: /home/ec2-user/sampay
+        state: directory
+        owner: ec2-user
+        group: ec2-user
+        mode: '0755'


### PR DESCRIPTION
This pull request includes updates to the deployment workflow and provisioning playbooks to improve the deployment process and ensure necessary directories are created.

### Deployment workflow improvements:
* [`.github/workflows/deploy.yaml`](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L65-R108): Added steps to set up Go, build backend binaries, and copy frontend files to EC2. Removed steps related to adhoc branch management.

### Provisioning playbook updates:
* [`provisioning/playbooks/backend.yaml`](diffhunk://#diff-fd075d8429ef6e1a418f518ccc0fa2e984928eeeecc219730f19cc48b1f69dddR89-R104): Added task to set `PACKAGE_ROOT` in `/etc/environment` and create the necessary directory for the backend.
* [`provisioning/playbooks/frontend.yaml`](diffhunk://#diff-6682104e717a22024e94a158cd307f227d18e2a9c53436ce0ad25ec2b8299215L16-L19): Removed `ExecStartPre` commands for npm in the frontend service definition and added a task to create the necessary directory for the frontend. [[1]](diffhunk://#diff-6682104e717a22024e94a158cd307f227d18e2a9c53436ce0ad25ec2b8299215L16-L19) [[2]](diffhunk://#diff-6682104e717a22024e94a158cd307f227d18e2a9c53436ce0ad25ec2b8299215R56-R63)