### PR TITLE
chore: use amazon linux minimal

### DIFF
--- a/infra/environments/stg/variables.tf
+++ b/infra/environments/stg/variables.tf
@@ -79,7 +79,7 @@ variable "instance_type" {
 
 variable "oauth_redirect_url" {
   description = "OAuth redirect URL"
-  type = string
+  type        = string
 }
 
 variable "redis_host" {

--- a/infra/modules/ec2/main.tf
+++ b/infra/modules/ec2/main.tf
@@ -40,18 +40,18 @@ resource "aws_key_pair" "ssh" {
   tags = local.common_tags
 }
 
-data "aws_ami" "amazon_linux_2023" {
+data "aws_ami" "amazon_linux_2023_minimal" {
   most_recent = true
   owners = ["amazon"]
 
   filter {
     name = "name"
-    values = ["al2023-ami-*-kernel-6.1-x86_64"]
+    values = ["al2023-ami-minimal-*-kernel-6.1-x86_64"]
   }
 }
 
 resource "aws_instance" "main" {
-  ami                         = data.aws_ami.amazon_linux_2023.id
+  ami                         = data.aws_ami.amazon_linux_2023_minimal.id
   associate_public_ip_address = true
   iam_instance_profile        = aws_iam_instance_profile.ec2_instance_profile.name
   instance_type               = var.instance_type


### PR DESCRIPTION
This pull request includes a change to the `infra/modules/ec2/main.tf` file to update the Amazon Machine Image (AMI) used for EC2 instances. The most important change is the switch from a standard Amazon Linux 2023 AMI to a minimal version of the Amazon Linux 2023 AMI.

Changes to AMI:

* [`infra/modules/ec2/main.tf`](diffhunk://#diff-50101eb89a8d563e5056cc6f851f9e659ba0d0a2ed08b85c3fc25c9552a286e3L43-R54): Updated the AMI data source from `amazon_linux_2023` to `amazon_linux_2023_minimal` and modified the filter values accordingly.
* [`infra/modules/ec2/main.tf`](diffhunk://#diff-50101eb89a8d563e5056cc6f851f9e659ba0d0a2ed08b85c3fc25c9552a286e3L43-R54): Updated the `ami` attribute of the `aws_instance` resource to use the new `amazon_linux_2023_minimal` AMI ID.