### PR TITLE
infra: add prod configuration

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,9 +1,19 @@
 name: Deploy Application
+
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deploy target environment'
+        required: true
+        default: 'stg'
+        type: choice
+        options:
+          - stg
+          - prod
   push:
     branches:
-      - "**"
+      - "main"
 
 permissions:
   id-token: write
@@ -13,18 +23,38 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+
     env:
       AWS_REGION: ap-northeast-1
-      DOMAIN: stg.sampay.link
+      ENV: ${{ github.event.inputs.environment || 'stg' }}
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set dynamic environment variables
+        id: set-env
+        run: |
+          if [ "${{ env.ENV }}" = "prod" ]; then
+            echo "DOMAIN=prod.sampay.link" >> $GITHUB_ENV
+            echo "SSH_PORT=${{ secrets.SSH_PORT_PROD }}" >> $GITHUB_ENV
+            echo "SECURITY_GROUP_ID=${{ secrets.SECURITY_GROUP_ID_PROD }}" >> $GITHUB_ENV
+            echo "POSTGRES_PASSWORD=${{ secrets.POSTGRES_ADMIN_PASSWORD_PROD }}" >> $GITHUB_ENV
+            echo "KVS_PASSWORD=${{ secrets.KVS_PASSWORD_PROD }}" >> $GITHUB_ENV
+            echo "EC2_SSH_KEY=${{ secrets.EC2_SSH_KEY_PROD }}" >> $GITHUB_ENV
+          else
+            echo "DOMAIN=stg.sampay.link" >> $GITHUB_ENV
+            echo "SSH_PORT=${{ secrets.SSH_PORT_STG }}" >> $GITHUB_ENV
+            echo "SECURITY_GROUP_ID=${{ secrets.SECURITY_GROUP_ID_STG }}" >> $GITHUB_ENV
+            echo "POSTGRES_PASSWORD=${{ secrets.POSTGRES_ADMIN_PASSWORD_STG }}" >> $GITHUB_ENV
+            echo "KVS_PASSWORD=${{ secrets.KVS_PASSWORD_STG }}" >> $GITHUB_ENV
+            echo "EC2_SSH_KEY=${{ secrets.EC2_SSH_KEY_STG }}" >> $GITHUB_ENV
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::590183691452:role/GitHubActionsRole-590183691452
-          aws-region: ap-northeast-1
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Get Public IP
         id: ip
@@ -33,14 +63,14 @@ jobs:
       - name: Allow IP in Security Group
         run: |
           aws ec2 authorize-security-group-ingress \
-          --group-id ${{ secrets.SECURITY_GROUP_ID_STG }} \
+          --group-id ${{ env.SECURITY_GROUP_ID }} \
           --protocol tcp \
-          --port ${{ secrets.SSH_PORT_STG }} \
+          --port ${{ env.SSH_PORT }} \
           --cidr ${{ steps.ip.outputs.ipv4 }}/32
 
       - name: Set up SSH
         run: |
-          echo "${{ secrets.EC2_SSH_KEY_STG }}" | base64 --decode > key.pem
+          echo "${{ env.EC2_SSH_KEY }}" | base64 --decode > key.pem
           chmod 600 key.pem
 
       - name: Set ansible vault password
@@ -53,16 +83,16 @@ jobs:
           cd ./provisioning
 
           export ANSIBLE_SSH_KEY="${GITHUB_WORKSPACE}/key.pem"
-          export ANSIBLE_SSH_PORT=${{ secrets.SSH_PORT_STG }}
+          export ANSIBLE_SSH_PORT=${{ env.SSH_PORT }}
           export AWS_REGION=${{ env.AWS_REGION }}
           export CERTBOT_EMAIL=${{ secrets.CERTBOT_EMAIL }}
-          export POSTGRES_PASSWORD=${{ secrets.POSTGRES_ADMIN_PASSWORD_STG }}
-          export KVS_PASSWORD=${{ secrets.KVS_PASSWORD_STG }}
+          export POSTGRES_PASSWORD=${{ env.POSTGRES_PASSWORD }}
+          export KVS_PASSWORD=${{ env.KVS_PASSWORD }}
           export BASIC_USER=${{ secrets.BASIC_USER }}
           export BASIC_PASSWORD=${{ secrets.BASIC_PASSWORD }}
 
           ansible-playbook -i ./inventory/web.yaml playbook.yaml \
-          --vault-password-file ./secrets/ansible_vault_pass --limit stg \
+          --vault-password-file ./secrets/ansible_vault_pass --limit ${{ env.ENV }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -79,36 +109,36 @@ jobs:
 
       - name: Ensure app directory exists
         run: |
-          ssh -p ${{ secrets.SSH_PORT_STG }} -i key.pem ec2-user@${{ env.DOMAIN }} -o StrictHostKeyChecking=no '
+          ssh -p ${{ env.SSH_PORT }} -i key.pem ec2-user@${{ env.DOMAIN }} -o StrictHostKeyChecking=no '
             mkdir -p /home/ec2-user/sampay
           '
 
       - name: Copy binaries to EC2 (build & db)
         run: |
-          scp -r -i key.pem -P ${{ secrets.SSH_PORT_STG }} -o StrictHostKeyChecking=no \
+          scp -r -i key.pem -P ${{ env.SSH_PORT }} -o StrictHostKeyChecking=no \
             ./backend/build ./backend/db ec2-user@${{ env.DOMAIN }}:/home/ec2-user/sampay/backend-${{ env.DIR_SUFFIX }}/
 
       - name: Deploy backend application
         run: |
           cat "${GITHUB_WORKSPACE}/backend/bin/deploy.sh" |
-          ssh -p ${{ secrets.SSH_PORT_STG }} -i key.pem ec2-user@${{ env.DOMAIN }} -o StrictHostKeyChecking=no '
+          ssh -p ${{ env.SSH_PORT }} -i key.pem ec2-user@${{ env.DOMAIN }} -o StrictHostKeyChecking=no '
             export DIR_SUFFIX="${{ env.DIR_SUFFIX }}";
-            export NGINX_CONF="/etc/nginx/conf.d/stg.sampay.link.conf";
+            export NGINX_CONF="/etc/nginx/conf.d/${{ env.DOMAIN }}.conf";
             export DOMAIN="${{ env.DOMAIN }}";
             bash -s
           '
 
       - name: Copy frontend files to EC2
         run: |
-          scp -C -r -i key.pem -P ${{ secrets.SSH_PORT_STG }} -o StrictHostKeyChecking=no \
+          scp -C -r -i key.pem -P ${{ env.SSH_PORT }} -o StrictHostKeyChecking=no \
             ./frontend ec2-user@${{ env.DOMAIN }}:/home/ec2-user/sampay/frontend-${{ env.DIR_SUFFIX }}
 
       - name: Deploy frontend application
         run: |
           cat "${GITHUB_WORKSPACE}/frontend/bin/deploy.sh" |
-          ssh -p ${{ secrets.SSH_PORT_STG }} -i key.pem ec2-user@${{ env.DOMAIN }} -o StrictHostKeyChecking=no '
+          ssh -p ${{ env.SSH_PORT }} -i key.pem ec2-user@${{ env.DOMAIN }} -o StrictHostKeyChecking=no '
             export DIR_SUFFIX="${{ env.DIR_SUFFIX }}";
-            export NGINX_CONF="/etc/nginx/conf.d/stg.sampay.link.conf";
+            export NGINX_CONF="/etc/nginx/conf.d/${{ env.DOMAIN }}.conf";
             export DOMAIN="${{ env.DOMAIN }}";
             bash -s
           '
@@ -117,7 +147,7 @@ jobs:
         if: ${{ always() }}
         run: |
           aws ec2 revoke-security-group-ingress \
-            --group-id ${{ secrets.SECURITY_GROUP_ID_STG }} \
+            --group-id ${{ env.SECURITY_GROUP_ID }} \
             --protocol tcp \
-            --port ${{ secrets.SSH_PORT_STG }} \
+            --port ${{ env.SSH_PORT }} \
             --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -5,9 +5,13 @@
 	apply-common \
 	destroy-common \
 	init-stg \
+	init-prod \
 	plan-stg \
+	plan-prod \
 	apply-stg \
+	apply-prod \
 	destroy-stg \
+	destroy-prod \
 	lint-init \
 	lint \
 	upgrade \
@@ -34,14 +38,33 @@ destroy-common:
 init-stg:
 	cd ./environments/stg && terraform init
 
+init-prod:
+	cd ./environments/prod && terraform init
+
 plan-stg:
 	cd ./environments/stg && terraform plan
+
+plan-prod:
+	cd ./environments/prod && terraform plan
 
 apply-stg:
 	cd ./environments/stg && terraform apply
 
+apply-prod:
+	cd ./environments/prod && terraform apply
+
 destroy-stg:
 	cd ./environments/stg && \
+	bash -c 'while read -r resource; do \
+		terraform destroy -target="$${resource}" -auto-approve; \
+	done < <( \
+		terraform state list | \
+		grep -vE "^data\\." | \
+		grep -vE "module.ssm.aws_ssm_parameter.random_values|module.ssm.random_password.secure_values|module.s3.aws_cloudfront_distribution.cdn" \
+	)'
+
+destroy-prod:
+	cd ./environments/prod && \
 	bash -c 'while read -r resource; do \
 		terraform destroy -target="$${resource}" -auto-approve; \
 	done < <( \

--- a/infra/environments/prod/.terraform.lock.hcl
+++ b/infra/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,108 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.84.0"
+  constraints = "5.84.0"
+  hashes = [
+    "h1:OJ53RNte7HLHSMxSkzu1S6H8sC0T8qnCAOcNLjjtMpc=",
+    "zh:078f77438aba6ec8bf9154b7d223e5c71c48d805d6cd3bcf9db0cc1e82668ac3",
+    "zh:1f6591ff96be00501e71b792ed3a5a14b21ff03afec9a1c4a3fd9300e6e5b674",
+    "zh:2ab694e022e81dd74485351c5836148a842ed71cf640664c9d871cb517b09602",
+    "zh:33c8ccb6e3dc496e828a7572dd981366c6271075c1189f249b9b5236361d7eff",
+    "zh:6f31068ebad1d627e421c72ccdaafe678c53600ca73714e977bf45ff43ae5d17",
+    "zh:7488623dccfb639347cae66f9001d39cf06b92e8081975235a1ac3a0ac3f44aa",
+    "zh:7f042b78b9690a8725c95b91a70fc8e264011b836605bcc342ac297b9ea3937d",
+    "zh:88b56ac6c7209dc0a775b79975a371918f3aed8f015c37d5899f31deff37c61a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1979ba840d704af0932f8de5f541cbb4caa9b6bbd25ed552a24e6772175ba07",
+    "zh:b058c0533dae580e69d1adbc1f69e6a80632374abfc10e8634d06187a108e87b",
+    "zh:c88610af9cf957f8dcf4382e0c9ca566ef10e3290f5de01d4d90b2d81b078aa8",
+    "zh:e9562c055a2247d0c287772b55abef468c79f8d66a74780fe1c5e5dae1a284a9",
+    "zh:f7a7c71d28441d925a25c08c4485c015b2d9f0338bc9707443e91ff8e161d3d9",
+    "zh:fee533e81976d0900aa6fa443dc54ef171cbd901847f28a6e8edb1d161fa6fde",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.3"
+  constraints = "3.2.3"
+  hashes = [
+    "h1:I0Um8UkrMUb81Fxq/dxbr3HLP2cecTH2WMJiwKSrwQY=",
+    "zh:22d062e5278d872fe7aed834f5577ba0a5afe34a3bdac2b81f828d8d3e6706d2",
+    "zh:23dead00493ad863729495dc212fd6c29b8293e707b055ce5ba21ee453ce552d",
+    "zh:28299accf21763ca1ca144d8f660688d7c2ad0b105b7202554ca60b02a3856d3",
+    "zh:55c9e8a9ac25a7652df8c51a8a9a422bd67d784061b1de2dc9fe6c3cb4e77f2f",
+    "zh:756586535d11698a216291c06b9ed8a5cc6a4ec43eee1ee09ecd5c6a9e297ac1",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9d5eea62fdb587eeb96a8c4d782459f4e6b73baeece4d04b4a40e44faaee9301",
+    "zh:a6355f596a3fb8fc85c2fb054ab14e722991533f87f928e7169a486462c74670",
+    "zh:b5a65a789cff4ada58a5baffc76cb9767dc26ec6b45c00d2ec8b1b027f6db4ed",
+    "zh:db5ab669cf11d0e9f81dc380a6fdfcac437aea3d69109c7aef1a5426639d2d65",
+    "zh:de655d251c470197bcbb5ac45d289595295acb8f829f6c781d4a75c8c8b7c7dd",
+    "zh:f5c68199f2e6076bce92a12230434782bf768103a427e9bb9abee99b116af7b5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.6.3"
+  constraints = "3.6.3"
+  hashes = [
+    "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.0.6"
+  constraints = ">= 4.0.0"
+  hashes = [
+    "h1:n3M50qfWfRSpQV9Pwcvuse03pEizqrmYEryxKky4so4=",
+    "zh:10de0d8af02f2e578101688fd334da3849f56ea91b0d9bd5b1f7a243417fdda8",
+    "zh:37fc01f8b2bc9d5b055dc3e78bfd1beb7c42cfb776a4c81106e19c8911366297",
+    "zh:4578ca03d1dd0b7f572d96bd03f744be24c726bfd282173d54b100fd221608bb",
+    "zh:6c475491d1250050765a91a493ef330adc24689e8837a0f07da5a0e1269e11c1",
+    "zh:81bde94d53cdababa5b376bbc6947668be4c45ab655de7aa2e8e4736dfd52509",
+    "zh:abdce260840b7b050c4e401d4f75c7a199fafe58a8b213947a258f75ac18b3e8",
+    "zh:b754cebfc5184873840f16a642a7c9ef78c34dc246a8ae29e056c79939963c7a",
+    "zh:c928b66086078f9917aef0eec15982f2e337914c5c4dbc31dd4741403db7eb18",
+    "zh:cded27bee5f24de6f2ee0cfd1df46a7f88e84aaffc2ecbf3ff7094160f193d50",
+    "zh:d65eb3867e8f69aaf1b8bb53bd637c99c6b649ba3db16ded50fa9a01076d1a27",
+    "zh:ecb0c8b528c7a619fa71852bb3fb5c151d47576c5aab2bf3af4db52588722eeb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.2.2"
+  constraints = "6.2.2"
+  hashes = [
+    "h1:DnqW/NW0VJAluU5CNXXxNpOdBbAFKjGn2+L/pC2SO9M=",
+    "zh:43d7e5f1e11d67e38ca717016d209d6d9a6fa03321b489f91984351bfb143b69",
+    "zh:46e788395034b410bf59dfa43eb748a3d81ecfd23fc442349990fd7d92bd856a",
+    "zh:5234b7d5c5817ff7ebec29756050708372a071a701e2c8236e714a0bd29ef160",
+    "zh:74c485a241cc8e8cb99f988d38116fb14e51de896761fc9ca35a34ca5c999a7e",
+    "zh:7606789521c50937913ea13f851150828b5f9b8804ba80c5b2538c0b019339d8",
+    "zh:760fb0e74590459689c7159456b6e76f165634f7d0f89f5572d56b57d387f645",
+    "zh:7979d9085d809bb7d0db2c67e6c3443d1c18d12e51b72220dcb4cc5e883cd64a",
+    "zh:8bed25d8199bf8b2e7ccf67edc1a4a2fc041bd490b2c11565c669b80be43896c",
+    "zh:9ff82a6279fb7ae0cd9e44f1e73b64dd2aeca43d4d3096f3f2866b1ebbcb9431",
+    "zh:a886055ecd63ccb9b880e3c3301c0eca9acb108580d12519617554ae2be9a393",
+    "zh:c1f20386704919c7964a95daffcb29f494efb061abc28469840df4532833cecf",
+    "zh:cb6e9c4e33d6a57770073867e174c09c0eed401ee70473a688d20cb1cf0394f7",
+    "zh:f89ca130cc90b87dc25d036fe8f8cadb6fb53dc33368a032c5cee6275f3bcddc",
+    "zh:f94a2d1174091f04ed361192cdda9503baa3d161849d4f218c55a96bfb1ea33d",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -1,0 +1,124 @@
+terraform {
+  backend "s3" {
+    bucket       = "sampay-tf-backend"
+    key          = "prod/state/terraform.tfstate"
+    region       = "ap-northeast-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}
+
+locals {
+  env = "prod"
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "github" {
+  token = var.github_token
+}
+
+module "ec2" {
+  source = "../../modules/ec2"
+
+  providers = {
+    aws    = aws
+    github = github
+  }
+
+  env = local.env
+
+  aws_region               = var.aws_region
+  domain                   = var.domain
+  email_from               = var.email_from
+  github_repo              = var.github_repo
+  instance_type            = var.instance_type
+  ssh_port                 = var.ssh_port
+  ssh_private_key          = module.ssm.private_key
+  ssh_public_key           = module.ssm.public_key
+  s3_public_bucket_arn     = module.s3.public_bucket_arn
+  sqs_worker_dlq_queue_arn = module.sqs.worker_dlq_arn
+  sqs_worker_queue_arn     = module.sqs.worker_arn
+  subnet_id                = module.vpc.public_subnet_id
+  volume_size              = var.volume_size
+  volume_type              = var.volume_type
+  vpc_security_group_ids = [
+    module.sg.sg_eic_id,
+    module.sg.sg_ssh_id,
+    module.sg.sg_web_id,
+  ]
+
+  depends_on = [
+    module.s3,
+    module.sg,
+    module.sqs,
+    module.ssm,
+    module.vpc,
+  ]
+}
+
+module "iam" {
+  source = "../../modules/iam"
+
+  github_repo_with_owner = var.github_repo_with_owner
+}
+
+module "s3" {
+  source = "../../modules/s3"
+  env    = local.env
+
+  geo_locations = var.geo_locations
+}
+
+module "sg" {
+  source = "../../modules/sg"
+  env    = local.env
+
+  github_repo = var.github_repo
+  ssh_port    = var.ssh_port
+  trusted_ip  = var.trusted_ip
+  vpc_id      = module.vpc.vpc_id
+}
+
+module "sqs" {
+  source = "../../modules/sqs"
+  env    = local.env
+}
+
+module "ssm" {
+  source = "../../modules/ssm"
+  env    = local.env
+
+  cloudfront_domain     = module.s3.cloudfront_domain
+  db_admin_user         = var.db_admin_user
+  db_host               = var.db_host
+  db_port               = var.db_port
+  db_timezone           = var.db_timezone
+  email_from            = var.email_from
+  frontend_base_url     = var.frontend_base_url
+  github_repo           = var.github_repo
+  google_client_id      = var.google_client_id
+  google_client_secret  = var.google_client_secret
+  oauth_redirect_url    = var.oauth_redirect_url
+  ssh_private_key_path  = var.ssh_private_key_path
+  ssh_public_key_path   = var.ssh_public_key_path
+  redis_host            = var.redis_host
+  redis_port            = var.redis_port
+  s3_public_bucket_name = module.s3.public_bucket_name
+  sqs_worker_dlq_url    = module.sqs.worker_url
+  sqs_worker_url        = module.sqs.worker_dlq_url
+
+  depends_on = [
+    module.s3,
+    module.sqs,
+  ]
+}
+
+module "vpc" {
+  source = "../../modules/vpc"
+  env    = local.env
+
+  vpc_cidr = var.vpc_cidr
+}

--- a/infra/environments/prod/provider.tf
+++ b/infra/environments/prod/provider.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.10.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.84.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "6.2.2"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.3"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0.0"
+    }
+  }
+}

--- a/infra/environments/prod/variables.tf
+++ b/infra/environments/prod/variables.tf
@@ -1,0 +1,130 @@
+variable "aws_region" {
+  description = "AWS region to deploy the Lightsail instance"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "db_admin_user" {
+  description = "Database admin user"
+  type        = string
+}
+
+variable "db_host" {
+  description = "Database host"
+  type        = string
+}
+
+variable "db_port" {
+  description = "Database port"
+  type        = number
+}
+
+variable "db_timezone" {
+  description = "Database timezone"
+  type        = string
+  default     = "Asia/Tokyo"
+}
+
+variable "domain" {
+  description = "Domain name"
+  type        = string
+}
+
+variable "email_from" {
+  description = "Email from"
+  type        = string
+}
+
+variable "frontend_base_url" {
+  description = "Frontend base URL"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repository name"
+  type        = string
+}
+
+variable "github_repo_with_owner" {
+  description = "GitHub repository with owner"
+  type        = string
+}
+
+variable "github_token" {
+  description = "GitHub token"
+  type        = string
+}
+
+variable "geo_locations" {
+  description = "Geo locations to allow access"
+  type = list(string)
+  default = ["JP"]
+}
+
+variable "google_client_id" {
+  description = "Google client ID"
+  type        = string
+}
+
+variable "google_client_secret" {
+  description = "Google client secret"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+}
+
+variable "oauth_redirect_url" {
+  description = "OAuth redirect URL"
+  type        = string
+}
+
+variable "redis_host" {
+  description = "Redis host"
+  type        = string
+}
+
+variable "redis_port" {
+  description = "Redis port"
+  type        = number
+}
+
+variable "ssh_port" {
+  description = "SSH port"
+  type        = number
+}
+
+variable "ssh_private_key_path" {
+  description = "Path to the private key"
+  type        = string
+}
+
+variable "ssh_public_key_path" {
+  description = "Path to the public key"
+  type        = string
+}
+
+variable "trusted_ip" {
+  description = "Trusted IP address"
+  type        = string
+}
+
+variable "volume_size" {
+  description = "Volume size in GB"
+  type        = number
+  default     = 8
+}
+
+variable "volume_type" {
+  description = "Volume type"
+  type        = string
+  default     = "gp2"
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR"
+  type        = string
+  default     = "10.0.0.0/16"
+}


### PR DESCRIPTION
This pull request introduces a new production environment configuration for Terraform. The changes include updates to the Makefile to support production commands, the addition of a new Terraform lock file, and new configuration files for the production environment.

### Makefile updates:
* Added production initialization, planning, applying, and destroying commands to the `infra/Makefile`. [[1]](diffhunk://#diff-f368c257c9bd34f470e444531b1361f73a55a4d38ff012e9370923585d75676cR8-R14) [[2]](diffhunk://#diff-f368c257c9bd34f470e444531b1361f73a55a4d38ff012e9370923585d75676cR41-R55) [[3]](diffhunk://#diff-f368c257c9bd34f470e444531b1361f73a55a4d38ff012e9370923585d75676cR66-R75)

### Terraform configuration:
* Created a new Terraform lock file for the production environment at `infra/environments/prod/.terraform.lock.hcl`. This file ensures consistent provider versions.
* Added a new main configuration file for the production environment at `infra/environments/prod/main.tf`. This file includes backend configuration, provider setups, and module definitions.
* Added a new provider configuration file for the production environment at `infra/environments/prod/provider.tf`. This file specifies the required provider versions.
* Added a new variables configuration file for the production environment at `infra/environments/prod/variables.tf`. This file defines all the necessary variables for the production setup.