### PR TITLE
fix: specify nginx max size

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -161,6 +161,7 @@ services:
       DOMAINS: 'api.sampay.lvh.me -> http://api:8080, sampay.lvh.me -> http://web:5173'
       STAGE: local
       WEBSOCKET: true
+      CLIENT_MAX_BODY_SIZE: 10m
     volumes:
       - ./https-portal/ssl_certs:/var/lib/https-portal
     depends_on:

--- a/frontend/app/routes/admin/admin-route.tsx
+++ b/frontend/app/routes/admin/admin-route.tsx
@@ -270,6 +270,7 @@ async function putLink({
       providerType: data.provider_type,
       uri: data.uri,
       name: data.name,
+      qrCode: imageObj,
     });
     const actionData: ActionData = {
       putLinkSuccess: true,

--- a/provisioning/playbooks/nginx.yaml
+++ b/provisioning/playbooks/nginx.yaml
@@ -107,6 +107,8 @@
               ssl_certificate /etc/letsencrypt/live/{{ domain_name }}/fullchain.pem;
               ssl_certificate_key /etc/letsencrypt/live/{{ domain_name }}/privkey.pem;
 
+              client_max_body_size 10m;
+
               location /api {
                   proxy_pass http://api;
                   proxy_http_version 1.1;


### PR DESCRIPTION
This pull request includes changes to `compose.yaml`, `admin-route.tsx`, and `nginx.yaml` to enhance the handling of client request sizes and improve functionality in the admin route. The most important changes are detailed below:

### Configuration Enhancements:

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR164): Added `CLIENT_MAX_BODY_SIZE` environment variable to set the maximum body size for client requests to 10MB.
* [`provisioning/playbooks/nginx.yaml`](diffhunk://#diff-ba34be48c0876f27426c4e86e8363a8ffc306c7c383123b037fa59e424dde74aR110-R111): Added `client_max_body_size 10m;` directive to the Nginx configuration to limit the size of client requests to 10MB.

### Functional Improvements:

* [`frontend/app/routes/admin/admin-route.tsx`](diffhunk://#diff-8d7f2896b9fe14530ce58c8298c9305ab2952d5e4a145a8e836ba514798a313fR273): Added `qrCode` to the data being sent in the `putLink` function to include QR code information in the admin route.